### PR TITLE
Sort out slowness issue. fixes #1

### DIFF
--- a/src/assets/styles/css/styles.css
+++ b/src/assets/styles/css/styles.css
@@ -92,7 +92,8 @@ li {
 
 @font-face {
   font-family: "pokemon";
-  src: url("../../fonts/pokemon_solid-webfont.woff") format("woff2"), url("../../fonts/pokemon_solid-webfont.woff2") format("woff");
+  src: url("../../fonts/pokemon_solid-webfont.woff") format("woff2"),
+    url("../../fonts/pokemon_solid-webfont.woff2") format("woff");
   font-weight: normal;
   font-style: normal;
 }
@@ -179,6 +180,13 @@ li {
   -moz-box-shadow: 5px 5px 10px 0px rgba(0, 0, 0, 0.5);
   box-shadow: 5px 5px 10px 0px rgba(0, 0, 0, 0.5);
   text-align: center;
+  min-height: 300px;
+  transition: opacity 0.5s ease-in-out;
+  opacity: 0;
+}
+
+.pokemon-card.visible {
+  opacity: 1;
 }
 
 .pokemon-card-img {
@@ -269,15 +277,6 @@ li {
 
 .fa-angle-up:hover {
   color: #fff;
-}
-
-.pokemon-card {
-  opacity: 0;
-  transition: all 1.5s ease-in-out;
-}
-
-.reveal-pokemon-card {
-  opacity: 1;
 }
 
 /*# sourceMappingURL=styles.css.map */


### PR DESCRIPTION
Hey Darsh

This fixes a few things..

First off, the problems:
- You was making quite a lot of API calls in 1 go (1 API call per pokemon), this was causing some throttling issues
- This is then compounded by the fact you also load all the images at the same time
- The reveal was too slow to respond.
- There was too much re-rendering happening at once causing everything to slow down entirely.

Solutions:
- Now only items in view make calls to the API, this means instead of making 150 API calls, you're only making 20 or less
- Only items in view load the image, again instead of thrashing the server, you're only downloading a few images at a time
- Instead of using `getBoundingClientRect` which is quite an expensive operation, I use intersectionOBserver which helps us know what is in view.


You will find it's much faster now
fixes https://github.com/Darsh2987/pokedex/issues/1

